### PR TITLE
chore(mn2-prep): eslint configuration 

### DIFF
--- a/contract/package.json
+++ b/contract/package.json
@@ -88,10 +88,7 @@
     ],
     "ignorePatterns": [
       "./node_modules"
-    ],
-    "rules": {
-      "no-void": "off"
-    }
+    ]
   },
   "prettier": {
     "trailingComma": "all",

--- a/contract/src/airdrop/prepare.js
+++ b/contract/src/airdrop/prepare.js
@@ -68,12 +68,13 @@ export const start = async (zcf, privateArgs, baggage) => {
     states,
     schedule: distributionSchedule,
     basePayoutQuantity,
-    brands: { Token: tokenBrand },
     issuers: { Token: tokenIssuer },
   } = zcf.getTerms();
 
   const claimedAccountsStore = zone.setStore('claimed users');
   // TODO: Inquire about handling state machine operations using a `Map` or `Set` from the Zone API.
+
+  // eslint-disable-next-line no-unused-vars
   const contractStateStore = zone.setStore('contract status');
 
   const stateMachine = makeStateMachine(initialState, stateTransitions);

--- a/contract/test/test-launchAirdrop.js
+++ b/contract/test/test-launchAirdrop.js
@@ -1,10 +1,11 @@
 // @ts-check
 // eslint-disable-next-line import/order
-import { test as anyTest } from './airdropData/prepare-test-env-ava.js';
 import { createRequire } from 'module';
 import { E } from '@endo/far';
 import { AmountMath, AssetKind } from '@agoric/ertp/src/amountMath.js';
 import { makeIssuerKit } from '@agoric/ertp';
+import { makeCopyBagFromElements, makeCopySet } from '@endo/patterns';
+import { test as anyTest } from './airdropData/prepare-test-env-ava.js';
 import { makeWalletFactory } from './wallet-tools.js';
 import { Id, IO, Task } from '../src/airdrop/adts/monads.js';
 import { launcherLarry, starterSam } from './market-actors.js';
@@ -21,7 +22,6 @@ import { makeStableFaucet } from './power-tools/mintStable.js';
 import { makeClientMarshaller } from '../src/marshalTables.js';
 import { documentStorageSchema } from './airdropData/storageDoc.js';
 import '@agoric/store/exported.js';
-import { makeCopyBagFromElements, makeCopySet } from '@endo/patterns';
 import { createDistributionConfig } from './utils.js';
 
 const nodeRequire = createRequire(import.meta.url);

--- a/contract/test/test-secp256k1.js
+++ b/contract/test/test-secp256k1.js
@@ -8,7 +8,10 @@ import { webcrypto } from 'node:crypto';
 import { hmac } from '@noble/hashes/hmac';
 import { sha256 } from '@noble/hashes/sha256';
 // @ts-ignore
-if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+// adopted from https://github.com/paulmillr/noble-hashes
+globalThis.crypto = webcrypto;
+
 secp.etc.hmacSha256Sync = (k, ...m) =>
   hmac(sha256, k, secp.etc.concatBytes(...m));
 secp.etc.hmacSha256Async = (k, ...m) =>

--- a/contract/test/test-start1.js
+++ b/contract/test/test-start1.js
@@ -1,8 +1,8 @@
 // @ts-check
-import { test as anyTest } from './prepare-test-env-ava.js';
 import { E } from '@endo/far';
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { createRequire } from 'module';
+import { test as anyTest } from './prepare-test-env-ava.js';
 import {
   bootAndInstallBundles,
   getBundleId,


### PR DESCRIPTION
* removed no-void rules stemming from vscode integration issues

* [x] contract lint config aligns with the required mn2 eslint rules

Refs: #28