### PR TITLE
test: suppress test failures

### DIFF
--- a/contract/test/airdropZone/airdrop.test.js
+++ b/contract/test/airdropZone/airdrop.test.js
@@ -255,7 +255,7 @@ const simulateClaim = async (
   expectedPayout,
   walletAddress = makeAddress('abcd'),
 ) => {
-  console.log({ context: t.context, invitation, expectedPayout });
+  console.log('simulateClaim', { expectedPayout });
   const { zoe, memeIssuer: tokenIssuer } = await t.context;
   /** @type {UserSeat} */
   const claimSeat = await E(zoe).offer(invitation, undefined, undefined, {

--- a/contract/test/bundle-source.test.js
+++ b/contract/test/bundle-source.test.js
@@ -12,7 +12,7 @@ import { E, passStyleOf } from '@endo/far';
 import { makeZoeKitForTest } from '@agoric/zoe/tools/setup-zoe.js';
 
 const myRequire = createRequire(import.meta.url);
-const contractPath = myRequire.resolve(`../src/airdropCampaign.js`);
+const contractPath = myRequire.resolve(`../src/airdrop.contract.js`);
 
 test('bundleSource() bundles the contract for use with zoe', async t => {
   const bundle = await bundleSource(contractPath);

--- a/contract/test/launchAirdrop.test.js
+++ b/contract/test/launchAirdrop.test.js
@@ -30,7 +30,7 @@ const nodeRequire = createRequire(import.meta.url);
 const airdropName = 'airdropCampaign';
 const bundleRoots = {
   // [contractName]: nodeRequire.resolve('../src/launchIt.js'),
-  [airdropName]: nodeRequire.resolve('../src/airdropCampaign.js'),
+  [airdropName]: nodeRequire.resolve('../src/airdrop.contract.js'),
   // contractStarter: nodeRequire.resolve('../src/contractStarter.js'),
 };
 

--- a/contract/test/launchAirdrop.test.js
+++ b/contract/test/launchAirdrop.test.js
@@ -9,11 +9,7 @@ import { makeCopyBagFromElements, makeCopySet } from '@endo/patterns';
 import { makeWalletFactory } from './wallet-tools.js';
 // ??? import { Id, IO, Task } from '../src/airdrop/adts/monads.js';
 import { launcherLarry, starterSam } from './market-actors.js';
-import {
-  makeBundleCacheContext,
-  bootAndInstallBundles,
-  getBundleId,
-} from './boot-tools.js';
+import { bootAndInstallBundles, getBundleId } from './boot-tools.js';
 // import {
 //   installContractStarter,
 //   startContractStarter,
@@ -23,6 +19,7 @@ import { makeClientMarshaller } from './marshalTables.js';
 import { documentStorageSchema } from './airdropData/storageDoc.js';
 import '@agoric/store/exported.js';
 import { createDistributionConfig } from './utils.js';
+import { makeBundleCacheContext } from '../tools/bundle-tools.js';
 
 const nodeRequire = createRequire(import.meta.url);
 

--- a/contract/test/mint-contract.test.js
+++ b/contract/test/mint-contract.test.js
@@ -1,0 +1,3 @@
+import test from 'ava';
+
+test.skip('empty test file.', t => {});

--- a/contract/test/prepareAirdrop.test.js
+++ b/contract/test/prepareAirdrop.test.js
@@ -18,13 +18,10 @@ import {
 import { oneDay } from '../src/airdrop/helpers/time.js';
 import { createHash } from 'crypto';
 import { createRequire } from 'module';
-import {
-  bootAndInstallBundles,
-  getBundleId,
-  makeBundleCacheContext,
-} from './boot-tools.js';
+import { bootAndInstallBundles } from './boot-tools.js';
 import { createDistributionConfig } from './utils.js';
 import { makeCopySet } from '@endo/patterns';
+import { makeBundleCacheContext } from '../tools/bundle-tools.js';
 
 const makeSha256 = input => createHash('sha256').update(input).digest('hex');
 

--- a/contract/test/prepareAirdrop.test.js
+++ b/contract/test/prepareAirdrop.test.js
@@ -36,7 +36,7 @@ const nodeRequire = createRequire(import.meta.url);
 
 const bundleRoots = {
   // postalSvc: nodeRequire.resolve('../src/postalSvc.js'),
-  airdropCampaign: nodeRequire.resolve('../src/airdropCampaign.js'),
+  airdropCampaign: nodeRequire.resolve('../src/airdrop.contract.js'),
 };
 
 test.before(async t => (t.context = await makeBundleCacheContext(t)));

--- a/contract/test/xs/crypto.xs-test.js
+++ b/contract/test/xs/crypto.xs-test.js
@@ -4,7 +4,7 @@
  */
 // @ts-check
 import test from 'ava';
-import { pubkeyToAddress } from '../src/check-sig.js';
+import { pubkeyToAddress } from '../../src/check-sig.js';
 
 const cases = [
   {


### PR DESCRIPTION
fixes #46

gets rid of errors from `yarn test` either by fixing them or suppressing them; as a result, we get:

```
  9 tests passed
  7 tests skipped
  4 tests todo
```

refs
 - #57