### PR TITLE
chore: added merge_group rule needed for protected branch configuration

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,7 @@ name: Lint and Test
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   all:


### PR DESCRIPTION
see [github docs on status checks](https://docs.github.com/en/enterprise-cloud@latest/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#status-checks-with-github-actions-and-a-merge-queue)