### PR TITLE
chore: cleanup console logs and unnecessary variables

### DIFF
--- a/contract/src/airdrop.contract.js
+++ b/contract/src/airdrop.contract.js
@@ -214,11 +214,7 @@ export const start = async (zcf, privateArgs, baggage) => {
    */
   const getDepositFacet = addr => {
     assert.typeof(addr, 'string');
-    console.log('geting deposit facet for::', addr);
-    const df = E(namesByAddress).lookup(addr, 'depositFacet');
-    console.log('------------------------');
-    console.log('df::', df);
-    return df;
+    return E(namesByAddress).lookup(addr, 'depositFacet');
   };
 
   /** @type {import('./airdrop.proposal.js').CustomContractTerms} */
@@ -358,13 +354,6 @@ export const start = async (zcf, privateArgs, baggage) => {
             targetNumberOfEpochs: this.state.targetNumberOfEpochs,
           });
 
-          console.group('UPDATE EPOCH DETAILS ##############');
-          console.log('------ epochLength', epochLength);
-          console.log('#####################################');
-          //            '#####################################'
-          //        );
-          console.log('------ epochIdx', epochIdx);
-          console.groupEnd();
           void helper.updateDistributionMultiplier(
             TimeMath.addAbsRel(absTime, toRT(epochLength)),
           );

--- a/contract/src/airdrop.proposal.js
+++ b/contract/src/airdrop.proposal.js
@@ -57,7 +57,7 @@ const publishBrandInfo = async (chainStorage, board, brand) => {
  * @typedef {{
  *   startTime: bigint;
  *   initialPayoutValues: any;
- *   targetNumberOfEpochs: number;
+ *   targetNumberOfEpochs: bigint;
  *   targetEpochLength: bigint;
  *   targetTokenSupply: bigint;
  *   tokenName: string;
@@ -67,7 +67,7 @@ const publishBrandInfo = async (chainStorage, board, brand) => {
 export const defaultCustomTerms = {
   startTime: 0n,
   initialPayoutValues: harden(AIRDROP_TIERS_STATIC),
-  targetNumberOfEpochs: 5,
+  targetNumberOfEpochs: 5n,
   targetEpochLength: 12_000n / 2n,
   targetTokenSupply: 10_000_000n * 1_000_000n,
   tokenName: 'Tribbles',


### PR DESCRIPTION
fix: update default type for "targetNumberOfEpochs"

refs: #165

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove console log statements and update `targetNumberOfEpochs` type from `number` to `bigint` in the airdrop contract codebase.

### Why are these changes being made?

The removal of console logs cleans up the code for production by eliminating unnecessary outputs, which are typically used only for debugging purposes. The update of `targetNumberOfEpochs` to `bigint` ensures a consistent type with other large numeric values, enhancing precision and avoiding potential overflow issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->